### PR TITLE
Fixed language taken from device settings instead of app language.

### DIFF
--- a/iOSKMP/iOSKMP.xcodeproj/project.pbxproj
+++ b/iOSKMP/iOSKMP.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		373615D82BA8250900F0854D /* iOSKMPUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373615D72BA8250900F0854D /* iOSKMPUITestsLaunchTests.swift */; };
 		373615E82BA846EC00F0854D /* CurrencyExchangeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373615E72BA846EC00F0854D /* CurrencyExchangeViewModel.swift */; };
 		3791F9712BCC468F005A0378 /* CurrencyExchangeKMP in Frameworks */ = {isa = PBXBuildFile; productRef = 3791F9702BCC468F005A0378 /* CurrencyExchangeKMP */; };
+		8463335E2BECFF8D00FF8E83 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8463335D2BECFF8D00FF8E83 /* Bundle+Extensions.swift */; };
 		8487BE022BCD852E0060B600 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8487BE012BCD852E0060B600 /* Color+Extensions.swift */; };
 		848E293C2BDBABFC0050FC23 /* MenuTabElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848E293B2BDBABFC0050FC23 /* MenuTabElement.swift */; };
 		848E293E2BDBAFD20050FC23 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848E293D2BDBAFD20050FC23 /* HomeCoordinator.swift */; };
@@ -83,6 +84,7 @@
 		373615D52BA8250900F0854D /* iOSKMPUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSKMPUITests.swift; sourceTree = "<group>"; };
 		373615D72BA8250900F0854D /* iOSKMPUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSKMPUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		373615E72BA846EC00F0854D /* CurrencyExchangeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyExchangeViewModel.swift; sourceTree = "<group>"; };
+		8463335D2BECFF8D00FF8E83 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		8487BE012BCD852E0060B600 /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		848E293B2BDBABFC0050FC23 /* MenuTabElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTabElement.swift; sourceTree = "<group>"; };
 		848E293D2BDBAFD20050FC23 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				8487BE012BCD852E0060B600 /* Color+Extensions.swift */,
 				84903B1A2BD189DE00B2F094 /* UIApplication+Extensions.swift */,
 				84C3D2622BE90316004C5E4F /* View+Extensions.swift */,
+				8463335D2BECFF8D00FF8E83 /* Bundle+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -598,6 +601,7 @@
 				373615BB2BA8250800F0854D /* CurrencyExchangeView.swift in Sources */,
 				373615E82BA846EC00F0854D /* CurrencyExchangeViewModel.swift in Sources */,
 				8499064F2BCEAD13002F9845 /* MenuTabView.swift in Sources */,
+				8463335E2BECFF8D00FF8E83 /* Bundle+Extensions.swift in Sources */,
 				84B6FBD92BDAB91A000F2532 /* TabBarCoordinatorDelegate.swift in Sources */,
 				849B5E882BDBFFF300D3233B /* SettingsCoordinatorDelegate.swift in Sources */,
 				8487BE022BCD852E0060B600 /* Color+Extensions.swift in Sources */,

--- a/iOSKMP/iOSKMP/Scenes/Settings/View/SettingsView.swift
+++ b/iOSKMP/iOSKMP/Scenes/Settings/View/SettingsView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("isDarkMode") private var isDarkMode = true
-    @AppStorage("locale") private var selectedLanguage: String = LanguageType.english.identifier
+    @AppStorage(Constants.darkModeKey) private var isDarkMode = true
+    @AppStorage(Constants.localeKey) private var selectedLanguage: String = LanguageType.english.identifier
     
     @Bindable private var viewModel: SettingsViewModel
     @Bindable private var router: Router

--- a/iOSKMP/iOSKMP/Supporting Files/Localizable.xcstrings
+++ b/iOSKMP/iOSKMP/Supporting Files/Localizable.xcstrings
@@ -7,23 +7,6 @@
     "%lf" : {
 
     },
-    "Acknowledgements" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acknowledgements"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconhecimentos"
-          }
-        }
-      }
-    },
     "App Size" : {
       "localizations" : {
         "pt-PT" : {
@@ -40,6 +23,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Versão do aplicativo"
+          }
+        }
+      }
+    },
+    "Back" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anterior"
           }
         }
       }
@@ -150,6 +144,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurações"
+          }
+        }
+      }
+    },
+    "VTAckAcknowledgements" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acknowledgements"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agradecimentos"
           }
         }
       }

--- a/iOSKMP/iOSKMP/Supporting Files/iOSKMPApp.swift
+++ b/iOSKMP/iOSKMP/Supporting Files/iOSKMPApp.swift
@@ -10,16 +10,30 @@ import CurrencyExchangeKMP
 
 @main
 struct iOSKMPApp: App {
+    // MARK: - Properties
+    
     private let tabBarCoordinator: RootCoordinator
+    
+    var body: some Scene {
+        WindowGroup {
+            tabBarCoordinator.start()
+        }
+    }
+    
+    // MARK: - Init
     
     init() {
         tabBarCoordinator = TabBarCoordinator()
         IOSKoinHelperKt.doInitKoin()
+        setupLocaleValue()
+        Bundle.swizzleLocalization()
     }
-
-    var body: some Scene {
-        WindowGroup {
-            tabBarCoordinator.start()
+    
+    // MARK: - Private methods
+    
+    private func setupLocaleValue() {
+        if UserDefaults.standard.value(forKey: Constants.localeKey) == nil {
+            UserDefaults.standard.setValue(LanguageType.english.identifier, forKey: Constants.localeKey)
         }
     }
 }

--- a/iOSKMP/iOSKMP/UIComponents/MenuTab/View/MenuTabView.swift
+++ b/iOSKMP/iOSKMP/UIComponents/MenuTab/View/MenuTabView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct MenuTabView: View {
-    @AppStorage("isDarkMode") private var isDarkMode = false
-    @AppStorage("locale") private var selectedLanguageIdentifier = LanguageType.english.identifier
+    @AppStorage(Constants.darkModeKey) private var isDarkMode = false
+    @AppStorage(Constants.localeKey) private var selectedLanguageIdentifier = LanguageType.english.identifier
     
     @Bindable private var viewModel: MenuTabViewModel
     

--- a/iOSKMP/iOSKMP/Utilities/Constants/Constants.swift
+++ b/iOSKMP/iOSKMP/Utilities/Constants/Constants.swift
@@ -24,5 +24,7 @@ enum Constants {
     static let minderaIcon: String = "MinderaIcon"
     // MARK: - String
     
+    static let localeKey: String = "locale"
+    static let darkModeKey: String = "isDarkMode"
     static let repositoryURLString: String = "https://github.com/Mindera/iOS-KMP-Template"
 }

--- a/iOSKMP/iOSKMP/Utilities/Extensions/Bundle+Extensions.swift
+++ b/iOSKMP/iOSKMP/Utilities/Extensions/Bundle+Extensions.swift
@@ -1,0 +1,33 @@
+//
+//  Bundle+Extensions.swift
+//  iOSKMP
+//
+//  Created by timea.varga on 09.05.2024.
+//
+
+import Foundation
+
+extension Bundle {
+    static func swizzleLocalization() {
+        let orginalSelector = #selector(localizedString(forKey:value:table:))
+        guard let orginalMethod = class_getInstanceMethod(self, orginalSelector) else { return }
+
+        let mySelector = #selector(myLocaLizedString(forKey:value:table:))
+        guard let myMethod = class_getInstanceMethod(self, mySelector) else { return }
+
+        if class_addMethod(self, orginalSelector, method_getImplementation(myMethod), method_getTypeEncoding(myMethod)) {
+            class_replaceMethod(self, mySelector, method_getImplementation(orginalMethod), method_getTypeEncoding(orginalMethod))
+        } else {
+            method_exchangeImplementations(orginalMethod, myMethod)
+        }
+    }
+
+    @objc private func myLocaLizedString(forKey key: String,value: String?, table: String?) -> String {
+        guard let language = UserDefaults.standard.value(forKey: Constants.localeKey) as? String,
+              let bundlePath = Bundle.main.path(forResource: language, ofType: "lproj"),
+            let bundle = Bundle(path: bundlePath) else {
+                return Bundle.main.myLocaLizedString(forKey: key, value: value, table: table)
+        }
+        return bundle.myLocaLizedString(forKey: key, value: value, table: table)
+    }
+}


### PR DESCRIPTION
We needed a way to handle localization of AknowList library, as it was using device language instead of app language selected by user. Using Method swizzling the implementation of `localizedString(forKey:value:table:` method could be changed to use the correct language identifier. 

For more information check: https://dev.to/eldare/forcing-ios-localization-at-runtime-the-right-way-2o24